### PR TITLE
heap: Prevent node chain collapse on free

### DIFF
--- a/source/mem/heap.c
+++ b/source/mem/heap.c
@@ -56,6 +56,7 @@ static u32 _heap_alloc(heap_t *heap, u32 size, u32 alignment)
 			node->used = 1;
 			new->used = 0;
 			new->next = node->next;
+			new->next->prev = new;
 			new->prev = node;
 			node->next = new;
 


### PR DESCRIPTION
This can cause use on free errors with the right sequence of heap usage